### PR TITLE
DEVOPS-1276: Test TORO Integrate Enterprise CloudFormation template

### DIFF
--- a/cloudformation-template/toro-integrate-enterprise.json
+++ b/cloudformation-template/toro-integrate-enterprise.json
@@ -4561,7 +4561,7 @@
             "Default": "20",
             "Description": "The size of the database (Gb)",
             "Type": "Number",
-            "MinValue": "30",
+            "MinValue": "20",
             "MaxValue": "1024",
             "ConstraintDescription": "must be between 5 and 1024Gb."
         },


### PR DESCRIPTION
>  Error
> Template validation error: Parameter DBAllocatedStorage failed to satisfy constraint: must be between 5 and 1024Gb.

Fix the error above by modifying the minvalue of the DBAllocatedStorage on the cloud formation template